### PR TITLE
Add text file ingestor microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ http://localhost:8007
 | Service                    | Port  | Description |
 |---------------------------|-------|-------------|
 | `now_ingestor`            | 8001  | Accepts signals |
+| `now_file_ingestor`       | 8010  | Ingests text files |
 | `express_emitter`         | 8002  | Broadcasts snapshot |
 | `interpret_service`       | 8003  | Parses tokens |
 | `reflect_service`         | 8004  | Runs truth filter |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,21 @@ services:
     depends_on:
       - genio_redis
 
+  now_file_ingestor:
+    build: ./now_file_ingestor
+    volumes:
+      - ./shared:/app/shared
+    ports:
+      - "8010:8000"
+    environment:
+      - PGHOST=postgres
+      - PGPORT=5432
+      - PGUSER=postgres
+      - PGPASSWORD=postgres
+      - PGDATABASE=genio
+    depends_on:
+      - genio_redis
+
   express_emitter:
     build: ./express_emitter
     volumes:

--- a/now_file_ingestor/Dockerfile
+++ b/now_file_ingestor/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/now_file_ingestor/main.py
+++ b/now_file_ingestor/main.py
@@ -1,0 +1,104 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from pydantic import BaseModel
+from uuid import uuid4
+from datetime import datetime
+import os
+import psycopg2
+from shared.logger import logger
+
+ALLOWED_EXTENSIONS = {'.txt', '.md', '.json'}
+STORAGE_ROOT = '/tmp/ingested_files'
+
+app = FastAPI(title="Genio Text File Ingestor")
+
+
+def get_db_connection():
+    return psycopg2.connect(
+        host=os.getenv('PGHOST', 'postgres'),
+        port=os.getenv('PGPORT', '5432'),
+        user=os.getenv('PGUSER', 'postgres'),
+        password=os.getenv('PGPASSWORD', 'postgres'),
+        dbname=os.getenv('PGDATABASE', 'genio')
+    )
+
+
+def init_db():
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ingested_files (
+                id UUID PRIMARY KEY,
+                filename TEXT,
+                filetype TEXT,
+                timestamp TIMESTAMP
+            )
+            """
+        )
+        conn.commit()
+        cur.close()
+        conn.close()
+    except Exception as e:
+        logger.error(f"DB init failed: {e}")
+
+
+@app.on_event("startup")
+def startup_event():
+    init_db()
+    os.makedirs(STORAGE_ROOT, exist_ok=True)
+
+
+class IngestResponse(BaseModel):
+    id: str
+    filename: str
+    filetype: str
+    timestamp: datetime
+    preview: str
+
+
+@app.post("/ingest", response_model=IngestResponse)
+async def ingest(file: UploadFile = File(...)):
+    ext = os.path.splitext(file.filename)[1].lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+
+    content_bytes = await file.read()
+    try:
+        text = content_bytes.decode('utf-8')
+    except UnicodeDecodeError:
+        text = content_bytes.decode('utf-8', errors='replace')
+
+    uid = str(uuid4())
+    ts = datetime.utcnow()
+    dir_path = os.path.join(STORAGE_ROOT, ts.strftime('%Y%m%d_%H%M%S'))
+    os.makedirs(dir_path, exist_ok=True)
+    file_path = os.path.join(dir_path, f"{uid}{ext}")
+    with open(file_path, 'wb') as f:
+        f.write(content_bytes)
+
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO ingested_files (id, filename, filetype, timestamp) VALUES (%s, %s, %s, %s)",
+            (uid, file.filename, ext.lstrip('.'), ts)
+        )
+        conn.commit()
+        cur.close()
+        conn.close()
+    except Exception as e:
+        logger.error(f"Failed to log to DB: {e}")
+
+    preview = text[:200]
+    logger.info(f"[NOW_FILE] Ingested {file.filename} as {uid}")
+    return IngestResponse(id=uid, filename=file.filename, filetype=ext.lstrip('.'), timestamp=ts, preview=preview)
+
+
+@app.get("/")
+def healthcheck():
+    return {"status": "now_file_ingestor active"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)

--- a/now_file_ingestor/requirements.txt
+++ b/now_file_ingestor/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+python-multipart
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add `now_file_ingestor` service to ingest text files via REST API
- log metadata to PostgreSQL
- store uploaded files temporarily
- document new service in README
- update docker-compose to include the service

## Testing
- `python -m py_compile now_file_ingestor/main.py`
