### PR TITLE
Revamp EXPRESS emitter as semantic encoding service

### DIFF
--- a/express_emitter/Dockerfile
+++ b/express_emitter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 # Set environment and working directory
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -16,4 +16,4 @@ RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Use uvicorn CLI to run app
-CMD ["python", "main.py"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/express_emitter/main.py
+++ b/express_emitter/main.py
@@ -1,25 +1,49 @@
-from fastapi import FastAPI
-from shared.redis_utils import subscribe, publish
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List
+from datetime import datetime
+from sentence_transformers import SentenceTransformer
+import asyncio
+import re
 from shared.logger import logger
-import threading, json, time
 
-app = FastAPI()
+app = FastAPI(title="Genio EXPRESS Semantic Encoding Service")
 
-def listener():
-    pubsub = subscribe("now_channel")
-    for message in pubsub.listen():
-        if message["type"] == "message":
-            data = json.loads(message["data"])
-            logger.info(f"[EXPRESS] Emitting: {data}")
-            publish("express_channel", data)
+MODEL_NAME = "all-MiniLM-L6-v2"
+model = SentenceTransformer(MODEL_NAME)
 
-# Start background listener
-threading.Thread(target=listener, daemon=True).start()
+class EncodeRequest(BaseModel):
+    uuid: str
+    text: str
+
+class EncodeResponse(BaseModel):
+    uuid: str
+    embedding: List[float]
+    timestamp: datetime
+    model: str
+
+def preprocess_text(text: str) -> str:
+    """Basic cleaning and whitespace normalization."""
+    text = re.sub(r"[^\w\s]", "", text)
+    return " ".join(text.split())
+
+@app.post("/encode", response_model=EncodeResponse)
+async def encode(req: EncodeRequest):
+    if not req.text or not req.text.strip():
+        logger.warning("[EXPRESS] Empty text received")
+        raise HTTPException(status_code=400, detail="Input text is empty")
+
+    cleaned = preprocess_text(req.text)
+    logger.info(f"[EXPRESS] Encoding uuid={req.uuid}")
+    loop = asyncio.get_event_loop()
+    embedding = await loop.run_in_executor(None, model.encode, cleaned)
+    return EncodeResponse(
+        uuid=req.uuid,
+        embedding=embedding.tolist(),
+        timestamp=datetime.utcnow(),
+        model=MODEL_NAME,
+    )
 
 @app.get("/")
-def root():
+async def healthcheck():
     return {"status": "express_emitter active"}
-
-# Keep app alive
-while True:
-    time.sleep(60)

--- a/express_emitter/requirements.txt
+++ b/express_emitter/requirements.txt
@@ -1,4 +1,5 @@
  
 fastapi
-redis
+uvicorn
 pydantic
+sentence-transformers


### PR DESCRIPTION
## Summary
- replace express_emitter pub/sub script with a FastAPI service
- add sentence transformer based `/encode` route
- update Dockerfile for Python 3.11 and uvicorn
- update requirements

## Testing
- `python -m py_compile express_emitter/main.py`