### PR TITLE
Add visualize_service microservice

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,15 @@ services:
     depends_on:
       - genio_redis
 
+  visualize_service:
+    build: ./visualize_service
+    volumes:
+      - ./shared:/app/shared
+    ports:
+      - "8008:8000"
+    depends_on:
+      - genio_redis
+
   qdrant:
     image: qdrant/qdrant
     ports:

--- a/visualize_service/Dockerfile
+++ b/visualize_service/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "main.py"]

--- a/visualize_service/main.py
+++ b/visualize_service/main.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
+from datetime import datetime
+from shared.logger import logger
+from schemas import VisualizeRequest, VisualizeResponse
+from visualization import generate_visualization
+import uvicorn
+
+app = FastAPI(title="Genio Visualize Service")
+app.mount("/static", StaticFiles(directory="."), name="static")
+
+@app.post("/visualize", response_model=VisualizeResponse)
+async def visualize(req: VisualizeRequest):
+    logger.info(f"[VISUALIZE] Request: {req.uuid}")
+    try:
+        path, vis_type = await generate_visualization(req.anchored_embedding, req.method, req.dimensions)
+        url = f"/static/{path}"
+        return VisualizeResponse(
+            uuid=req.uuid,
+            visualization_url=url,
+            visualization_type=vis_type,
+            timestamp=datetime.utcnow()
+        )
+    except ValueError as e:
+        logger.error(f"[VISUALIZE] Invalid request: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"[VISUALIZE] Error generating visualization: {e}")
+        raise HTTPException(status_code=500, detail="Visualization failed")
+
+@app.get("/")
+async def healthcheck():
+    return {"status": "visualize_service active"}
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)

--- a/visualize_service/requirements.txt
+++ b/visualize_service/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+pydantic
+numpy
+scikit-learn
+plotly

--- a/visualize_service/schemas.py
+++ b/visualize_service/schemas.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict
+from datetime import datetime
+
+class VisualizeRequest(BaseModel):
+    uuid: str
+    anchored_embedding: List[float] = Field(..., description="Validated embedding vector")
+    metadata: Optional[Dict] = None
+    method: Optional[str] = Field("pca", description="Visualization method: pca or tsne")
+    dimensions: Optional[int] = Field(2, description="Target dimension: 2 or 3")
+
+class VisualizeResponse(BaseModel):
+    uuid: str
+    visualization_url: str
+    visualization_type: str
+    timestamp: datetime

--- a/visualize_service/visualization.py
+++ b/visualize_service/visualization.py
@@ -1,0 +1,34 @@
+import os
+import uuid
+from typing import List, Tuple
+import numpy as np
+from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+import plotly.express as px
+import asyncio
+
+async def generate_visualization(embedding: List[float], method: str = "pca", dimensions: int = 2) -> Tuple[str, str]:
+    if dimensions not in (2, 3):
+        raise ValueError("dimensions must be 2 or 3")
+    if method not in ("pca", "tsne"):
+        raise ValueError("method must be 'pca' or 'tsne'")
+
+    async def _create_plot() -> str:
+        X = np.array(embedding).reshape(1, -1)
+        if method == "tsne":
+            reducer = TSNE(n_components=dimensions)
+        else:
+            reducer = PCA(n_components=dimensions)
+        reduced = reducer.fit_transform(X)
+        if dimensions == 3:
+            fig = px.scatter_3d(x=reduced[:,0], y=reduced[:,1], z=reduced[:,2])
+        else:
+            fig = px.scatter(x=reduced[:,0], y=reduced[:,1])
+        os.makedirs("visualizations", exist_ok=True)
+        file_id = f"{uuid.uuid4()}.html"
+        path = os.path.join("visualizations", file_id)
+        fig.write_html(path)
+        return path
+
+    path = await asyncio.to_thread(_create_plot)
+    return path, f"{method.upper()}_{dimensions}D"


### PR DESCRIPTION
## Summary
- add `visualize_service` for embedding visualization
- implement visualization logic using PCA/t-SNE
- expose `/visualize` POST endpoint
- containerize the service and add to compose file

## Testing
- `python -m py_compile visualize_service/*.py`
