### PR TITLE
Refactor reflect_service to anchor embeddings

### DIFF
--- a/reflect_service/Dockerfile
+++ b/reflect_service/Dockerfile
@@ -1,6 +1,11 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
+
 WORKDIR /app
+
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
 COPY . .
-CMD ["python", "main.py"]
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/reflect_service/main.py
+++ b/reflect_service/main.py
@@ -1,44 +1,11 @@
 from fastapi import FastAPI
-from shared.redis_utils import subscribe, publish
 from shared.logger import logger
-import threading, json
+from .routes import router
 
-app = FastAPI()
+app = FastAPI(title="Genio REFLECT Service")
 
-def truth_anchor(tokens):
-    has_meaning = any(t.lower() in ["truth", "memory", "waking", "vision", "life", "soul"] for t in tokens)
-    is_useful = len(tokens) > 2
-    return has_meaning and is_useful
-
-def listener():
-    logger.info("[REFLECT] Starting listener on interpret_channel")
-    try:
-        pubsub = subscribe("interpret_channel")
-        logger.info("[REFLECT] Subscribed successfully.")
-        for message in pubsub.listen():
-            logger.info(f"[REFLECT] Received raw message: {message}")
-            if message["type"] == "message":
-                try:
-                    data = json.loads(message["data"])
-                    tokens = data.get("tokens", [])
-                    logger.info(f"[REFLECT] Reviewing Tokens: {tokens}")
-                    if truth_anchor(tokens):
-                        logger.info(f"[TRUTH] Validated as Meaningful and Useful.")
-                        publish("reflect_channel", {"tokens": tokens, "truth": True})
-                    else:
-                        logger.info(f"[TRUTH] Rejected: Lacked meaning or utility.")
-                except Exception as e:
-                    logger.error(f"[REFLECT] Error processing message: {e}")
-    except Exception as e:
-        logger.error(f"[REFLECT] Failed to subscribe: {e}")
-
-threading.Thread(target=listener, daemon=True).start()
+app.include_router(router)
 
 @app.get("/")
-def healthcheck():
+async def healthcheck():
     return {"status": "reflect_service active"}
-
-# RUN FASTAPI PROPERLY
-import uvicorn
-if __name__ == "__main__":
-    uvicorn.run("main:app", host="0.0.0.0", port=8000)

--- a/reflect_service/requirements.txt
+++ b/reflect_service/requirements.txt
@@ -1,5 +1,5 @@
  
 fastapi
-redis
 pydantic
+numpy
 uvicorn

--- a/reflect_service/routes.py
+++ b/reflect_service/routes.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, HTTPException
+from datetime import datetime
+from shared.logger import logger
+from .schemas import AnchorRequest, AnchorResponse
+from .validation import validate_embedding
+
+router = APIRouter()
+
+@router.post("/anchor", response_model=AnchorResponse)
+async def anchor(request: AnchorRequest):
+    try:
+        anchored, status, summary = await validate_embedding(request.pruned_embedding)
+        response = AnchorResponse(
+            uuid=request.uuid,
+            anchored_embedding=anchored,
+            status=status,
+            timestamp=datetime.utcnow(),
+            summary=summary
+        )
+        logger.info(f"[REFLECT] {request.uuid} => {status} : {summary}")
+        return response
+    except Exception as e:
+        logger.error(f"[REFLECT] Error: {e}")
+        raise HTTPException(status_code=400, detail=str(e))

--- a/reflect_service/schemas.py
+++ b/reflect_service/schemas.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import List, Optional
+from datetime import datetime
+
+class AnchorRequest(BaseModel):
+    uuid: str
+    pruned_embedding: List[float]
+    metadata: Optional[dict] = None
+
+class AnchorResponse(BaseModel):
+    uuid: str
+    anchored_embedding: List[float]
+    status: str
+    timestamp: datetime
+    summary: Optional[str] = None

--- a/reflect_service/validation.py
+++ b/reflect_service/validation.py
@@ -1,0 +1,29 @@
+from typing import List, Tuple
+from datetime import datetime
+import os
+import numpy as np
+
+ANCHOR_THRESHOLD = float(os.getenv("ANCHOR_THRESHOLD", 0.5))
+
+async def validate_embedding(embedding: List[float]) -> Tuple[List[float], str, str]:
+    if not embedding:
+        return embedding, "rejected", "empty embedding"
+
+    array = np.array(embedding, dtype=float)
+    anchor = np.zeros_like(array)
+    diff = np.linalg.norm(array - anchor)
+
+    if diff <= ANCHOR_THRESHOLD:
+        status = "valid"
+        anchored = array
+        summary = "within threshold"
+    elif diff <= ANCHOR_THRESHOLD * 2:
+        status = "adjusted"
+        anchored = array * (ANCHOR_THRESHOLD / diff)
+        summary = "scaled to threshold"
+    else:
+        status = "rejected"
+        anchored = array
+        summary = "exceeded threshold"
+
+    return anchored.tolist(), status, summary


### PR DESCRIPTION
## Summary
- refactor reflect_service into modern FastAPI microservice
- add `/anchor` endpoint with request/response models
- implement embedding validation logic
- update Dockerfile to Python 3.11 and run via uvicorn
- simplify requirements

## Testing
- `python -m py_compile reflect_service/*.py`
- `pytest -q` *(fails: no tests found)*