### PR TITLE
[VIEW] - React frontend scaffolding

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }],
+  ],
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Genio</title>
+  </head>
+  <body class="bg-gray-900 text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/index.jsx"></script>
+  </body>
+</html>

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest',
+  },
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "genio-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.5.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "jest": "^29.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "babel-jest": "^29.0.0",
+    "@babel/preset-env": "^7.22.0",
+    "@babel/preset-react": "^7.18.6"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/components/LiveFeedDock.jsx
+++ b/frontend/src/components/LiveFeedDock.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function LiveFeedDock() {
+  // TODO: connect to websocket for live updates
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-2">Live Feed</h2>
+      <div className="space-y-2 text-sm text-gray-300">
+        <p>Waiting for incoming memories...</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MemoryEntryForm.jsx
+++ b/frontend/src/components/MemoryEntryForm.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+export default function MemoryEntryForm() {
+  const [content, setContent] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // TODO: wire to /memory/ingest endpoint
+    console.log('submit', content);
+    setContent('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 mt-4">
+      <textarea
+        className="w-full bg-gray-800 border border-gray-700 rounded p-2"
+        rows="3"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Add memory snapshot..."
+      />
+      <button
+        type="submit"
+        className="w-full bg-blue-600 hover:bg-blue-700 text-white p-2 rounded"
+      >
+        Ingest Memory
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/MemoryTimeline.jsx
+++ b/frontend/src/components/MemoryTimeline.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useMockMemory } from '../hooks/useMockMemory';
+
+export default function MemoryTimeline() {
+  const memories = useMockMemory();
+
+  return (
+    <div className="space-y-4">
+      {memories.map((mem) => (
+        <div
+          key={mem.id}
+          className="border border-gray-700 rounded p-4 hover:bg-gray-800 transition-colors"
+        >
+          <div className="text-sm text-gray-400 flex justify-between">
+            <span>{new Date(mem.timestamp).toLocaleString()}</span>
+            <span className="font-semibold">w:{mem.weight}</span>
+          </div>
+          <p className="mt-2">{mem.content}</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {mem.tags.map((tag) => (
+              <span
+                key={tag}
+                className="text-xs bg-gray-700 px-2 py-1 rounded-full"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/PersonaDriftVisualizer.jsx
+++ b/frontend/src/components/PersonaDriftVisualizer.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function PersonaDriftVisualizer() {
+  return (
+    <div className="border border-gray-700 p-4 rounded">
+      <h2 className="text-lg font-semibold mb-2">Persona Drift</h2>
+      <p className="text-sm text-gray-400">Visualization coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/src/components/SearchFilterPanel.jsx
+++ b/frontend/src/components/SearchFilterPanel.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function SearchFilterPanel() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Search &amp; Filter</h2>
+      <input
+        className="w-full bg-gray-800 border border-gray-700 rounded p-2"
+        type="text"
+        placeholder="Search tags or text"
+      />
+      <div className="flex space-x-2 text-sm">
+        <input type="date" className="bg-gray-800 border border-gray-700 rounded p-1 flex-1" />
+        <input type="date" className="bg-gray-800 border border-gray-700 rounded p-1 flex-1" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SessionReplayViewer.jsx
+++ b/frontend/src/components/SessionReplayViewer.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function SessionReplayViewer() {
+  return (
+    <div className="border border-gray-700 p-4 rounded">
+      <h2 className="text-lg font-semibold mb-2">Session Replay</h2>
+      <p className="text-sm text-gray-400">Replay controls coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/MemoryTimeline.test.jsx
+++ b/frontend/src/components/__tests__/MemoryTimeline.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MemoryTimeline from '../MemoryTimeline';
+
+jest.mock('../../hooks/useMockMemory', () => ({
+  useMockMemory: () => [
+    { id: 1, timestamp: 0, weight: 1, tags: ['test'], content: 'Hello' },
+  ],
+}));
+
+describe('MemoryTimeline', () => {
+  it('renders memory entries', () => {
+    render(<MemoryTimeline />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/useMockMemory.js
+++ b/frontend/src/hooks/useMockMemory.js
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+export function useMockMemory() {
+  const [memories] = useState(() => [
+    {
+      id: 1,
+      timestamp: Date.now() - 1000 * 60 * 60,
+      weight: 0.8,
+      tags: ['start', 'mock'],
+      content: 'Initial memory snapshot of Genio.',
+    },
+    {
+      id: 2,
+      timestamp: Date.now() - 1000 * 30,
+      weight: 0.5,
+      tags: ['update'],
+      content: 'Second memory entry demonstrating the timeline.',
+    },
+  ]);
+
+  return memories;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './pages/App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import MemoryTimeline from '../components/MemoryTimeline';
+import MemoryEntryForm from '../components/MemoryEntryForm';
+import LiveFeedDock from '../components/LiveFeedDock';
+import SearchFilterPanel from '../components/SearchFilterPanel';
+
+export default function App() {
+  return (
+    <div className="min-h-screen flex flex-col md:flex-row">
+      <aside className="md:w-1/4 p-4 border-r border-gray-700">
+        <SearchFilterPanel />
+        <MemoryEntryForm />
+      </aside>
+      <main className="flex-1 p-4 overflow-y-auto space-y-4">
+        <MemoryTimeline />
+      </main>
+      <div className="md:w-1/5 border-l border-gray-700 p-4">
+        <LiveFeedDock />
+      </div>
+    </div>
+  );
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  darkMode: 'class',
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold React app using Vite and TailwindCSS
- implement basic layout with memory timeline, entry form, search panel and live feed dock
- include placeholder components for persona drift and session replay
- add jest test for MemoryTimeline component

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f21e0c3e883328a00eebae4928bb2