### PR TITLE
[FRONTEND] Ingest fixes, search filters, spiral view

### DIFF
--- a/frontend/src/components/LiveFeedDock.jsx
+++ b/frontend/src/components/LiveFeedDock.jsx
@@ -1,13 +1,20 @@
 import React from 'react';
+import SpiralCanvas from './SpiralCanvas';
 
-export default function LiveFeedDock() {
-  // TODO: connect to websocket for live updates
+export default function LiveFeedDock({ messages = [], memories = [] }) {
   return (
-    <div>
+    <div className="flex flex-col h-full">
       <h2 className="text-lg font-semibold mb-2">Live Feed</h2>
-      <div className="space-y-2 text-sm text-gray-300">
-        <p>Waiting for incoming memories...</p>
+      <div className="flex-1 overflow-y-auto space-y-1 text-sm text-gray-300 bg-gray-800 p-2 rounded">
+        {messages.length ? (
+          messages.map((m, i) => (
+            <div key={i} className="whitespace-pre-wrap">{m}</div>
+          ))
+        ) : (
+          <p>Waiting for incoming memories...</p>
+        )}
       </div>
+      <SpiralCanvas memories={memories} />
     </div>
   );
 }

--- a/frontend/src/components/MemoryEntryForm.jsx
+++ b/frontend/src/components/MemoryEntryForm.jsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react';
 
-export default function MemoryEntryForm({ onIngestComplete }) {
+export default function MemoryEntryForm({ onIngestComplete, onLog }) {
   const [content, setContent] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-
     if (!content.trim()) return;
 
     try {
@@ -16,16 +15,15 @@ export default function MemoryEntryForm({ onIngestComplete }) {
       });
 
       if (response.ok) {
-        console.log('✅ Memory ingested');
+        onLog?.(`[ingest] ${new Date().toLocaleTimeString()} - Memory ingested`);
         setContent('');
-        if (typeof onIngestComplete === 'function') {
-          onIngestComplete(); // 🔁 trigger timeline reload
-        }
+        onIngestComplete?.();
       } else {
-        console.error('❌ Ingest failed:', await response.text());
+        const msg = await response.text();
+        onLog?.(`[error] ${msg}`);
       }
     } catch (err) {
-      console.error('🚨 Network error:', err);
+      onLog?.(`[error] ${err}`);
     }
   };
 

--- a/frontend/src/components/SearchFilterPanel.jsx
+++ b/frontend/src/components/SearchFilterPanel.jsx
@@ -1,18 +1,36 @@
 import React from 'react';
 
-export default function SearchFilterPanel() {
+export default function SearchFilterPanel({ keyword, startDate, endDate, onChange, onClear }) {
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-semibold">Search &amp; Filter</h2>
       <input
         className="w-full bg-gray-800 border border-gray-700 rounded p-2"
         type="text"
+        value={keyword}
+        onChange={(e) => onChange({ keyword: e.target.value })}
         placeholder="Search tags or text"
       />
       <div className="flex space-x-2 text-sm">
-        <input type="date" className="bg-gray-800 border border-gray-700 rounded p-1 flex-1" />
-        <input type="date" className="bg-gray-800 border border-gray-700 rounded p-1 flex-1" />
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => onChange({ startDate: e.target.value })}
+          className="bg-gray-800 border border-gray-700 rounded p-1 flex-1"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => onChange({ endDate: e.target.value })}
+          className="bg-gray-800 border border-gray-700 rounded p-1 flex-1"
+        />
       </div>
+      <button
+        onClick={onClear}
+        className="text-sm text-blue-400 hover:underline"
+      >
+        Clear Filters
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/SpiralCanvas.jsx
+++ b/frontend/src/components/SpiralCanvas.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useRef } from 'react';
+
+/**
+ * Minimal canvas-based 3D spiral visualization.
+ * Provides a lightweight alternative to Three.js in offline environments.
+ */
+export default function SpiralCanvas({ memories = [], onSelect }) {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width = canvas.clientWidth;
+    const h = canvas.height = canvas.clientHeight;
+    const centerX = w / 2;
+    const centerY = h / 2;
+    const fov = 300;
+
+    ctx.clearRect(0, 0, w, h);
+    memories.forEach((m, i) => {
+      const angle = i * 0.3;
+      const radius = 5 * i;
+      const x3 = radius * Math.cos(angle);
+      const y3 = radius * Math.sin(angle);
+      const z3 = i * 5;
+      const scale = fov / (fov + z3);
+      const x2 = centerX + x3 * scale;
+      const y2 = centerY + y3 * scale;
+      const size = 4 * scale;
+      ctx.beginPath();
+      ctx.fillStyle = '#60a5fa';
+      ctx.arc(x2, y2, size, 0, Math.PI * 2);
+      ctx.fill();
+    });
+  }, [memories]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="w-full h-40 border border-gray-700 mt-4"
+    ></canvas>
+  );
+}

--- a/frontend/src/components/__tests__/MemoryEntryForm.test.jsx
+++ b/frontend/src/components/__tests__/MemoryEntryForm.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import MemoryEntryForm from '../MemoryEntryForm';
+
+global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => ({}) }));
+
+describe('MemoryEntryForm', () => {
+  it('calls ingest endpoint and clears textarea', async () => {
+    const onIngestComplete = jest.fn();
+    render(<MemoryEntryForm onIngestComplete={onIngestComplete} />);
+    const textarea = screen.getByPlaceholderText('Add memory snapshot...');
+    fireEvent.change(textarea, { target: { value: 'test memory' } });
+    fireEvent.submit(textarea.closest('form'));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch.mock.calls[0][0]).toMatch('/memory/ingest');
+    expect(onIngestComplete).toHaveBeenCalled();
+    expect(textarea.value).toBe('');
+  });
+});

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -1,46 +1,68 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import MemoryTimeline from '../components/MemoryTimeline';
 import MemoryEntryForm from '../components/MemoryEntryForm';
 import LiveFeedDock from '../components/LiveFeedDock';
 import SearchFilterPanel from '../components/SearchFilterPanel';
+import { filterMemories } from '../utils/filterMemories';
 
 export default function App() {
   const [timelineData, setTimelineData] = useState([]);
+  const [feedMessages, setFeedMessages] = useState([]);
+  const [filters, setFilters] = useState({ keyword: '', startDate: '', endDate: '' });
 
-const fetchTimeline = async () => {
-  try {
-    const res = await fetch('http://localhost:8007/memory/replay');
-    const data = await res.json();
-
-    const mapped = data.map((item, index) => ({
-      id: item.uuid || index,
-      timestamp: item.timestamp,
-      content: item.tokens ? item.tokens.join(' ') : '(no content)',
-      weight: item.weight || 1.0,
-      tags: item.tags || []
-    }));
-
-    setTimelineData(mapped);
-  } catch (err) {
-    console.error('Error fetching timeline:', err);
-  }
-};
+  const fetchTimeline = async () => {
+    try {
+      const res = await fetch('http://localhost:8007/memory/replay');
+      const data = await res.json();
+      const mapped = data.map((item, index) => ({
+        id: item.uuid || index,
+        timestamp: item.timestamp,
+        content: item.tokens ? item.tokens.join(' ') : '(no content)',
+        weight: item.weight || 1.0,
+        tags: item.tags || [],
+      }));
+      setTimelineData(mapped);
+    } catch (err) {
+      console.error('Error fetching timeline:', err);
+    }
+  };
 
   useEffect(() => {
     fetchTimeline();
   }, []);
 
+  const filteredTimeline = useMemo(
+    () => filterMemories(timelineData, filters),
+    [timelineData, filters]
+  );
+
+  const handleLog = (msg) => {
+    setFeedMessages((m) => [...m.slice(-50), msg]);
+  };
+
+  const handleFilterChange = (patch) => {
+    setFilters((f) => ({ ...f, ...patch }));
+  };
+
+  const handleClearFilters = () => setFilters({ keyword: '', startDate: '', endDate: '' });
+
   return (
     <div className="min-h-screen bg-gray-900 text-white flex flex-col md:flex-row">
-      <aside className="md:w-1/4 p-4 border-r border-gray-700">
-        <SearchFilterPanel />
-        <MemoryEntryForm onIngestComplete={fetchTimeline} />
+      <aside className="md:w-1/4 p-4 border-r border-gray-700 space-y-4">
+        <SearchFilterPanel
+          keyword={filters.keyword}
+          startDate={filters.startDate}
+          endDate={filters.endDate}
+          onChange={handleFilterChange}
+          onClear={handleClearFilters}
+        />
+        <MemoryEntryForm onIngestComplete={fetchTimeline} onLog={handleLog} />
       </aside>
       <main className="flex-1 p-4 overflow-y-auto space-y-4">
-        <MemoryTimeline data={timelineData} />
+        <MemoryTimeline data={filteredTimeline} />
       </main>
-      <div className="md:w-1/5 border-l border-gray-700 p-4">
-        <LiveFeedDock />
+      <div className="md:w-1/5 border-l border-gray-700 p-4 flex flex-col">
+        <LiveFeedDock messages={feedMessages} memories={timelineData} />
       </div>
     </div>
   );

--- a/frontend/src/utils/__tests__/filterMemories.test.js
+++ b/frontend/src/utils/__tests__/filterMemories.test.js
@@ -1,0 +1,20 @@
+import { filterMemories } from '../filterMemories';
+
+describe('filterMemories', () => {
+  const data = [
+    { timestamp: '2023-01-01T00:00:00Z', content: 'Hello world', tags: ['greet'] },
+    { timestamp: '2023-02-01T00:00:00Z', content: 'Another entry', tags: ['test'] },
+  ];
+
+  it('filters by keyword', () => {
+    const result = filterMemories(data, { keyword: 'hello' });
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('Hello world');
+  });
+
+  it('filters by date range', () => {
+    const result = filterMemories(data, { startDate: '2023-01-15', endDate: '2023-03-01' });
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('Another entry');
+  });
+});

--- a/frontend/src/utils/filterMemories.js
+++ b/frontend/src/utils/filterMemories.js
@@ -1,0 +1,23 @@
+/**
+ * Filter a list of memory objects based on keyword and date range.
+ * @param {Array} memories - Memory objects with at least `content`, `tags`, and `timestamp` fields.
+ * @param {Object} filters - Filters { keyword?: string, startDate?: string, endDate?: string }
+ * @returns {Array} Filtered memories.
+ */
+export function filterMemories(memories, { keyword = '', startDate = '', endDate = '' } = {}) {
+  const kw = keyword.trim().toLowerCase();
+  const start = startDate ? new Date(startDate) : null;
+  const end = endDate ? new Date(endDate) : null;
+
+  return memories.filter((m) => {
+    if (kw) {
+      const haystack = `${m.content ?? ''} ${Array.isArray(m.tags) ? m.tags.join(' ') : ''}`.toLowerCase();
+      if (!haystack.includes(kw)) {
+        return false;
+      }
+    }
+    if (start && new Date(m.timestamp) < start) return false;
+    if (end && new Date(m.timestamp) > end) return false;
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- add memory filter utility with tests
- update MemoryEntryForm to emit logs and notify on ingest
- show feed messages and spiral visualization
- add search filter panel wiring
- update App to manage filters, feed, and timeline
- add Jest tests for ingest form and filtering

## Testing
- `npm test --silent` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842ece9b9c08332bfeb16178870de21