### PR TITLE
[NOW] Add SCADA CSV ingestion

### DIFF
--- a/frontend/src/components/IngestPanel.jsx
+++ b/frontend/src/components/IngestPanel.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import MemoryEntryForm from './MemoryEntryForm';
+
+export default function IngestPanel({ onIngestComplete, onLog }) {
+  const [file, setFile] = useState(null);
+  const [rows, setRows] = useState(null);
+
+  const handleUpload = async () => {
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const res = await fetch('http://localhost:8001/ingest/scada', {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await res.json();
+      if (res.ok) {
+        onLog?.(`[scada] ${data.rows_ingested} rows ingested`);
+        setRows(data.rows_ingested);
+        onIngestComplete?.();
+      } else {
+        onLog?.(`[error] ${data.errors?.join(', ')}`);
+      }
+    } catch (err) {
+      onLog?.(`[error] ${err}`);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <MemoryEntryForm onIngestComplete={onIngestComplete} onLog={onLog} />
+      <div className="space-y-2">
+        <input
+          data-testid="csv-file"
+          type="file"
+          accept=".csv"
+          onChange={(e) => setFile(e.target.files[0])}
+          className="text-sm"
+        />
+        {file && (
+          <div className="text-xs text-gray-300">{file.name}</div>
+        )}
+        <button
+          onClick={handleUpload}
+          disabled={!file}
+          className="w-full bg-green-600 hover:bg-green-700 text-white p-2 rounded"
+        >
+          Upload CSV
+        </button>
+        {rows !== null && (
+          <div className="text-xs">Rows processed: {rows}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/IngestPanel.test.jsx
+++ b/frontend/src/components/__tests__/IngestPanel.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import IngestPanel from '../IngestPanel';
+
+global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => ({ rows_ingested: 1 }) }));
+
+describe('IngestPanel', () => {
+  it('uploads selected CSV file', async () => {
+    render(<IngestPanel />);
+    const input = screen.getByTestId('csv-file');
+    const file = new File(['DateTime\n'], 'test.csv', { type: 'text/csv' });
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText('Upload CSV'));
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch.mock.calls[0][0]).toMatch('/ingest/scada');
+  });
+});

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import MemoryTimeline from '../components/MemoryTimeline';
-import MemoryEntryForm from '../components/MemoryEntryForm';
+import IngestPanel from '../components/IngestPanel';
 import LiveFeedDock from '../components/LiveFeedDock';
 import SearchFilterPanel from '../components/SearchFilterPanel';
 import { filterMemories } from '../utils/filterMemories';
@@ -56,7 +56,7 @@ export default function App() {
           onChange={handleFilterChange}
           onClear={handleClearFilters}
         />
-        <MemoryEntryForm onIngestComplete={fetchTimeline} onLog={handleLog} />
+        <IngestPanel onIngestComplete={fetchTimeline} onLog={handleLog} />
       </aside>
       <main className="flex-1 p-4 overflow-y-auto space-y-4">
         <MemoryTimeline data={filteredTimeline} />

--- a/now_ingestor/requirements.txt
+++ b/now_ingestor/requirements.txt
@@ -5,3 +5,4 @@ loguru
 psycopg2-binary
 redis[hiredis]
 python-multipart
+pandas

--- a/now_ingestor/scada_utils.py
+++ b/now_ingestor/scada_utils.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+import pandas as pd
+
+
+def parse_scada_timestamp(value: str) -> str:
+    """Convert SCADA DateTime string to ISO 8601 UTC string."""
+    base = value.split("-")[0].strip()
+    dt = datetime.strptime(base, "%m/%d/%Y %H:%M")
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def row_to_memory(row: pd.Series | Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a SCADA CSV row into a memory dict."""
+    if isinstance(row, dict):
+        row = pd.Series(row)
+
+    ts_iso = parse_scada_timestamp(str(row["DateTime"]))
+
+    signal = {
+        "diff_pressure_inH20": float(row["diff_pressure_inH20"]),
+        "static_pressure_psia": float(row["static_pressure_psia"]),
+        "temperature_degF": float(row["temperature_degF"]),
+        "volume_mcf": float(row["volume_mcf"]),
+        "flow_rate_mcf_day": float(row["flow_rate_mcf_day"]),
+        "energy_mmbtu": float(row["energy_mmbtu"]),
+        "flow_time_pct": float(row["flow_time_pct"]),
+        "alarms": str(row.get("alarms", "")),
+    }
+
+    memory = {
+        "timestamp": ts_iso,
+        "signal": signal,
+        "source": "scada",
+        "tags": ["scada", "automated", "sensor"],
+        "content": f"SCADA reading flow={signal['flow_rate_mcf_day']} at {ts_iso}",
+    }
+    return memory

--- a/now_ingestor/tests/test_scada_utils.py
+++ b/now_ingestor/tests/test_scada_utils.py
@@ -1,0 +1,33 @@
+import sys
+import types
+import os
+
+# Ensure project root on path for module imports
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, ROOT)
+
+sys.modules['pandas'] = types.SimpleNamespace(Series=dict)
+from now_ingestor.scada_utils import parse_scada_timestamp, row_to_memory
+import pandas as pd
+
+
+def test_parse_scada_timestamp():
+    assert parse_scada_timestamp("05/07/2024 00:00-01:00") == "2024-05-07T00:00:00Z"
+
+
+def test_row_to_memory():
+    row = pd.Series({
+        "DateTime": "05/07/2024 00:00-01:00",
+        "diff_pressure_inH20": 1.0,
+        "static_pressure_psia": 2.0,
+        "temperature_degF": 3.0,
+        "volume_mcf": 4.0,
+        "flow_rate_mcf_day": 5.0,
+        "energy_mmbtu": 6.0,
+        "flow_time_pct": 7.0,
+        "alarms": "none",
+    })
+    mem = row_to_memory(row)
+    assert mem["source"] == "scada"
+    assert mem["signal"]["flow_rate_mcf_day"] == 5.0
+    assert mem["timestamp"] == "2024-05-07T00:00:00Z"


### PR DESCRIPTION
## Summary
- add CSV upload panel for SCADA files
- route uploaded SCADA rows through the memory loop
- support SCADA parsing helpers and tests
- update requirements

## Testing
- `pytest -q`
- `npm test --silent` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842f398f64483328637e6b6073c1e8a